### PR TITLE
feat: add feature for customizing Details link URL

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -34,6 +34,11 @@ async function updateShaStatus(body, res) {
     const userConfigBase64 = JSON.parse(config.body).content;
 
     const failureMessages = [];
+    const failureURLs = [];
+    const defaultFailureURL = `https://github.com/${
+      body.repository.full_name
+    }/blob/${body.pull_request.head.sha}/.github/prlint.json`;
+
     let userConfig;
 
     try {
@@ -53,9 +58,12 @@ async function updateShaStatus(body, res) {
               let message = `Rule \`${element}[${index}]\` failed`;
               message = item.message || message;
               failureMessages.push(message);
+              const URL = item.URL || defaultFailureURL;
+              failureURLs.push(URL);
             }
           } catch (e) {
             failureMessages.push(e);
+            failureURLs.push(defaultFailureURL);
           }
         });
       });
@@ -70,15 +78,15 @@ async function updateShaStatus(body, res) {
       };
     } else {
       let description = failureMessages[0];
+      let URL = failureURLs[0];
       if (failureMessages.length > 1) {
         description = `1/${failureMessages.length - 1}: ${description}`;
+        URL = defaultFailureURL;
       }
       bodyPayload = {
         state: 'failure',
         description: description.slice(0, 140), // 140 characters is a GitHub limit
-        target_url: `https://github.com/${body.repository.full_name}/blob/${
-          body.pull_request.head.sha
-        }/.github/prlint.json`,
+        target_url: URL,
         context: 'PRLint',
       };
     }

--- a/src/app.js
+++ b/src/app.js
@@ -58,7 +58,7 @@ async function updateShaStatus(body, res) {
               let message = `Rule \`${element}[${index}]\` failed`;
               message = item.message || message;
               failureMessages.push(message);
-              const URL = item.URL || defaultFailureURL;
+              const URL = item.detailsURL || defaultFailureURL;
               failureURLs.push(URL);
             }
           } catch (e) {

--- a/test/prlint-config-sample.json
+++ b/test/prlint-config-sample.json
@@ -3,14 +3,14 @@
     {
       "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test):\\s",
       "message": "Your PR title doesn’t match our schema",
-      "URL": "https://gph.is/1c4zf2O"
+      "detailsURL": "https://gph.is/1c4zf2O"
     }
   ],
   "head.ref": [
     {
       "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test)/",
       "message": "Your branch name is invalid",
-      "URL": "https://gph.is/1c4zf2O"
+      "detailsURL": "https://gph.is/1c4zf2O"
     }
   ]
 }

--- a/test/prlint-config-sample.json
+++ b/test/prlint-config-sample.json
@@ -2,13 +2,15 @@
   "title": [
     {
       "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test):\\s",
-      "message": "Your PR title doesn’t match our schema"
+      "message": "Your PR title doesn’t match our schema",
+      "URL": "https://gph.is/1c4zf2O"
     }
   ],
   "head.ref": [
     {
       "pattern": "^(build|ci|docs|feat|fix|perf|refactor|style|test)/",
-      "message": "Your branch name is invalid"
+      "message": "Your branch name is invalid",
+      "URL": "https://gph.is/1c4zf2O"
     }
   ]
 }


### PR DESCRIPTION
As discussed in #48, introduce a root-level `detailsURL` key to allow users to customize where the "Details" link points to, whenever the PR linting fails.